### PR TITLE
PART 메서드 구현 및 비밀번호 없는 서버 에러 처리

### DIFF
--- a/Executer.hpp
+++ b/Executer.hpp
@@ -58,6 +58,7 @@ public:
 	int pingCommand();
 	int quitCommand();
 	int joinCommand();
+	int partCommand();
 };
 
 #endif

--- a/Server.cpp
+++ b/Server.cpp
@@ -41,6 +41,9 @@ void Server::run() {
 void Server::makeNewConnection() {
 	int clnt_sock = _serv.acceptSock();
 	Client *clnt = new Client(clnt_sock);
+	if (_password.empty()) {
+		clnt->setPassed(true);
+	}
 	_data_manager.addClient(clnt);
 	_kq.addEvent(clnt_sock, EVFILT_READ);
 	// _kq.setTimer(clnt_sock);

--- a/Server.cpp
+++ b/Server.cpp
@@ -134,10 +134,10 @@ void Server::parsing(Client *clnt) {
 		}
 		else if (executer.getCommand() == "JOIN") {
 			flag = executer.joinCommand();
-		} /* else if (executer.getCommand() == "PRIVMSG") {
-			flag = executer.msgCommand();
 		} else if (executer.getCommand() == "PART") {
 			flag = executer.partCommand();
+		} /* else if (executer.getCommand() == "PRIVMSG") {
+			flag = executer.msgCommand();
 		} else if (executer.getCommand() == "KICK") {
 			flag = executer.kickCommand();
 		} else if (executer.getCommand() == "MODE") {


### PR DESCRIPTION
### PART 메서드 구현
- 성공적으로 채널을 떠난 경우
- 클라이언트가 채널에 참여하지 않은 경우
- 채널이 존재하지 않는 경우
- 매개변수가 부족한 경우

### 비밀번호 없는 서버 에러 처리
- 비밀번호 설정 되어 있지 않을 경우 setPassed(True)로 설정