### PR TITLE
QUIT, KICK 에러 처리

### DIFF
--- a/Executor.cpp
+++ b/Executor.cpp
@@ -245,13 +245,11 @@ void Executor::partCommand() {
 	}
 }
 
-// 명령어 입력 시 채널은 앞에 # 꼭 붙이기
 void Executor::kickCommand() {
 	std::string chan_name(getParams(0));
 	Channel *chan = _data_manager->getChannel(chan_name.substr(1));
 	std::stringstream ss_user(getParams(1));
 	std::vector<std::string> users;
-	std::string comment(getParams(2));
 	std::string token;
 	while (std::getline(ss_user, token, ',')) {
 		users.push_back(token);
@@ -274,12 +272,7 @@ void Executor::kickCommand() {
 			} else if (!_data_manager->isChannelMember(chan, _data_manager->getClient(_data_manager->getFdByNickname(users[i])))) {
 				throw std::logic_error(makeSource(SERVER) + " 441 " + _clnt->getNickname() + " " + chan_name + " :They aren't on that channel\r\n");
 			}
-			std::string kick_message = makeSource(CLIENT) + " KICK " + chan_name + " " + users[i] + " ";
-			if (!comment.empty()) {
-				kick_message.append(comment);
-			}
-			kick_message.append("\r\n");
-			_data_manager->sendToChannel(chan, kick_message);
+			_data_manager->sendToChannel(chan, makeSource(CLIENT) + " KICK " + chan_name + " " + users[i] + " " + getParams(2) + "\r\n");
 			_data_manager->delClientFromChannel(_data_manager->getClient(_data_manager->getFdByNickname(users[i])), chan);
 		}
 	} catch(const std::exception& e) {

--- a/Executor.cpp
+++ b/Executor.cpp
@@ -139,7 +139,14 @@ void Executor::pongCommand() {
 }
 
 void Executor::quitCommand() {
-	_data_manager->sendToClient(_clnt, makeSource(CLIENT) + " QUIT :Quit: " + getParams(0) + "\r\n");
+	_data_manager->sendToClientChannels(_clnt, makeSource(CLIENT) + " QUIT :Quit: " + getParams(0) + "\r\n");
+	std::set<std::string> chans = _clnt->getJoinedChannels();
+	for (std::set<std::string>::iterator it = chans.begin(); it != chans.end(); ++it) {
+		Channel *chan = _data_manager->getChannel(*it);
+		if (chan != nullptr) {
+			_data_manager->delClientFromChannel(_clnt, chan);
+		}
+	}
 	_clnt->setPassed(false);
 }
 

--- a/Executor.cpp
+++ b/Executor.cpp
@@ -282,7 +282,7 @@ void Executor::kickCommand() {
 				kick_message.append(" :You are kicked\r\n");
 			}
 			_data_manager->sendToChannel(chan, kick_message);
-			_data_manager->delClientFromChannel(_clnt, chan);
+			_data_manager->delClientFromChannel(_data_manager->getClient(_data_manager->getFdByNickname(users[i])), chan);
 		}
 	} catch(const std::exception& e) {
 		_data_manager->sendToClient(_clnt, e.what());

--- a/Executor.cpp
+++ b/Executor.cpp
@@ -277,10 +277,8 @@ void Executor::kickCommand() {
 			std::string kick_message = makeSource(CLIENT) + " KICK " + chan_name + " " + users[i] + " ";
 			if (!comment.empty()) {
 				kick_message.append(comment);
-				kick_message.append("\r\n");
-			} else {
-				kick_message.append(" :You are kicked\r\n");
 			}
+			kick_message.append("\r\n");
 			_data_manager->sendToChannel(chan, kick_message);
 			_data_manager->delClientFromChannel(_data_manager->getClient(_data_manager->getFdByNickname(users[i])), chan);
 		}

--- a/Executor.cpp
+++ b/Executor.cpp
@@ -269,7 +269,9 @@ void Executor::kickCommand() {
 			throw std::logic_error(makeSource(SERVER) + " 482 " + _clnt->getNickname() + " " + chan_name + " :You're not channel operator\r\n");
 		}
 		for (size_t i = 0; i < users.size(); i++) {
-			if (!_data_manager->isChannelMember(chan, _data_manager->getClient(_data_manager->getFdByNickname(users[i])))) {
+			if (_data_manager->getFdByNickname(users[i]) == -1 || !_data_manager->getClient(_data_manager->getFdByNickname(users[i]))) {
+				throw std::logic_error(makeSource(SERVER) + " 401 " + _clnt->getNickname() + " " + users[i] + " :No such nick\r\n");
+			} else if (!_data_manager->isChannelMember(chan, _data_manager->getClient(_data_manager->getFdByNickname(users[i])))) {
 				throw std::logic_error(makeSource(SERVER) + " 441 " + _clnt->getNickname() + " " + chan_name + " :They aren't on that channel\r\n");
 			}
 			std::string kick_message = makeSource(CLIENT) + " KICK " + chan_name + " " + users[i] + " ";


### PR DESCRIPTION
## QUIT
- QUIT 메서드에서 참여한 모든 채널에 메시지 전송 및 채널 나가기
close #12 
## KICK
- KICK 메서드에서 sendToChannel() 함수 호출 단순화
- KICK comment 없을 경우 메시지 수정 (삭제)
- KICK 대상 수정
  - KICK 명령어 입력한 사람 -> KICK 대상자로 변경
close #49 
- 채널/서버에 존재하지 않는 닉네임 에러 처리
close #50 