### PR TITLE
채널에 _topic_only 변수 추가

### DIFF
--- a/Channel.cpp
+++ b/Channel.cpp
@@ -1,7 +1,7 @@
 
 #include "Channel.hpp"
 
-Channel::Channel(std::string const &name): _name(name), _limit(-1), _inviteOnly(false), _created(time(NULL)) {
+Channel::Channel(std::string const &name): _name(name), _limit(-1), _invite_only(false), _topic_only(true), _created(time(NULL)) {
 }
 
 Channel::~Channel() {}
@@ -18,8 +18,8 @@ void Channel::setLimit(size_t limit) {
 	_limit = limit;
 }
 
-void Channel::setInviteOnly(bool inviteOnly) {
-	_inviteOnly = inviteOnly;
+void Channel::setInviteOnly(bool invite_only) {
+	_invite_only = invite_only;
 }
 
 void Channel::setTopic(std::string const &topic, int author_fd) {
@@ -65,7 +65,11 @@ size_t Channel::getLimit() const {
 }
 
 bool Channel::getInviteOnly() const {
-	return _inviteOnly;
+	return _invite_only;
+}
+
+bool Channel::getTopicOnly() const {
+	return _topic_only;
 }
 
 size_t Channel::getClientNum() {
@@ -109,10 +113,10 @@ int Channel::isInvited(int fd) {
 
 std::string Channel::getModeList() {
 	std::string mode_list;
-	if (_inviteOnly) {
+	if (_invite_only) {
 		mode_list.append("i");
 	}
-	if (_topic.empty()) {
+	if (_topic_only) {
 		mode_list.append("t");
 	}
 	if (_limit >= 0) {

--- a/Channel.hpp
+++ b/Channel.hpp
@@ -18,7 +18,8 @@ private:
 	std::string _topic;
 	std::string _key; // 비밀번호
 	int _limit;	  // 최대 인원 수
-	bool _inviteOnly; // 초대만 가능
+	bool _invite_only; // 초대만 가능
+	bool _topic_only; // 토픽 권한
 
 	time_t _created;
 	time_t _topic_created;
@@ -50,6 +51,7 @@ public:
 	std::string const &getKey() const;
 	size_t getLimit() const;
 	bool getInviteOnly() const;
+	bool getTopicOnly() const;
 	std::map<int, int> &getClients();
 	std::vector<int> getClientsFd();
 	std::string getModeList();


### PR DESCRIPTION
resolves: #54 
채널에 _topic_only를 추가했습니다. true -> 채널권한이 있어야 topic 변경가능, false-> 모두가 변경가능
getModeList도 수정했습니다


On most servers, newly-created channels have then [protected topic "+t"](https://modern.ircdocs.horse/#protected-topic-mode)
참고하여 첫 생성시 기본 설정은 true가 되도록 했습니다.