### PR TITLE
TOPIC 메서드 구현

### DIFF
--- a/Channel.cpp
+++ b/Channel.cpp
@@ -1,7 +1,7 @@
 
 #include "Channel.hpp"
 
-Channel::Channel(std::string const &name): _name(name), _limit(-1), _invite_only(false), _topic_only(true), _created(time(NULL)) {
+Channel::Channel(std::string const &name): _name(name), _topic(NULL), _limit(-1), _invite_only(false), _topic_only(true), _created(time(NULL)) {
 }
 
 Channel::~Channel() {}

--- a/Channel.cpp
+++ b/Channel.cpp
@@ -1,7 +1,7 @@
 
 #include "Channel.hpp"
 
-Channel::Channel(std::string const &name): _name(name), _topic(NULL), _limit(-1), _invite_only(false), _topic_only(true), _created(time(NULL)) {
+Channel::Channel(std::string const &name): _name(name), _topic(""), _limit(-1), _invite_only(false), _topic_only(true), _created(time(NULL)) {
 }
 
 Channel::~Channel() {}

--- a/Executor.cpp
+++ b/Executor.cpp
@@ -260,23 +260,19 @@ void Executor::partCommand() {
 
 void Executor::topicCommand() {
 	std::string chan_name(getParams(0));
-	Channel *chan = _data_manager->getChannel(chan_name);
+	Channel *chan = _data_manager->getChannel(chan_name.substr(1));
 	std::string topic(getParams(1));
 	try {
 		if (!_clnt->getPassed()) {
 			throw std::logic_error(makeSource(SERVER) + " 461 " + _clnt->getNickname() + " PASS :Not enough parameters\r\n");
 		} else if (_params.size() < 1) {
 			throw std::logic_error(makeSource(SERVER) + " 461 " + _clnt->getNickname() + " TOPIC :Not enough parameters\r\n");
-		} else if (topic.empty()) {
-			if (chan->getTopic().empty()) {
-				throw std::logic_error(makeSource(SERVER) + " 331 " + _clnt->getNickname() + " " + chan_name + " No topic is set\r\n");
-			_data_manager->sendToClient(_clnt, makeSource(SERVER) + " 332 " + _clnt->getNickname() + " " + chan_name + " " + topic + "\r\n");
-			_data_manager->sendToClient(_clnt, makeSource(SERVER) + " 333 " + _clnt->getNickname() + " " + chan_name + " " + _data_manager->getClient(chan->getTopicAuthor())->getNickname() + " " + chan->getTopicCreated() + "\r\n");
-			}
 		} else if (!_data_manager->isChannelMember(chan, _clnt)) {
 			throw std::logic_error(makeSource(SERVER) + " 442 " + _clnt->getNickname() + " " + chan_name + " :You're not on that channel\r\n");
 		} else if (!_data_manager->isChannelOperator(chan, _clnt) && chan->getTopicOnly()) {
 			throw std::logic_error(makeSource(SERVER) + " 482 " + _clnt->getNickname() + " " + chan_name + " :You're not channel operator\r\n");
+		} else if (chan->getTopic() == topic) {
+			return ;
 		}
 		chan->setTopic(topic, _clnt->getFd());
 		_data_manager->sendToChannel(chan, makeSource(CLIENT) + " TOPIC " + chan_name + " " + topic + "\r\n", -1);

--- a/Executor.cpp
+++ b/Executor.cpp
@@ -270,13 +270,16 @@ void Executor::topicCommand() {
 		} else if (topic.empty()) {
 			if (chan->getTopic().empty()) {
 				throw std::logic_error(makeSource(SERVER) + " 331 " + _clnt->getNickname() + " " + chan_name + " No topic is set\r\n");
-
+			_data_manager->sendToClient(_clnt, makeSource(SERVER) + " 332 " + _clnt->getNickname() + " " + chan_name + " " + topic + "\r\n");
+			_data_manager->sendToClient(_clnt, makeSource(SERVER) + " 333 " + _clnt->getNickname() + " " + chan_name + " " + _data_manager->getClient(chan->getTopicAuthor())->getNickname() + " " + chan->getTopicCreated() + "\r\n");
 			}
 		} else if (!_data_manager->isChannelMember(chan, _clnt)) {
 			throw std::logic_error(makeSource(SERVER) + " 442 " + _clnt->getNickname() + " " + chan_name + " :You're not on that channel\r\n");
-		} else if (!_data_manager->isChannelOperator(chan, _clnt)) {
+		} else if (!_data_manager->isChannelOperator(chan, _clnt) && chan->getTopicOnly()) {
 			throw std::logic_error(makeSource(SERVER) + " 482 " + _clnt->getNickname() + " " + chan_name + " :You're not channel operator\r\n");
 		}
+		chan->setTopic(topic, _clnt->getFd());
+		_data_manager->sendToChannel(chan, makeSource(CLIENT) + " TOPIC " + chan_name + " " + topic + "\r\n", -1);
 	} catch (const std::exception &e) {
 		_data_manager->sendToClient(_clnt, e.what());
 	}

--- a/Executor.cpp
+++ b/Executor.cpp
@@ -267,6 +267,8 @@ void Executor::topicCommand() {
 			throw std::logic_error(makeSource(SERVER) + " 461 " + _clnt->getNickname() + " PASS :Not enough parameters\r\n");
 		} else if (_params.size() < 1) {
 			throw std::logic_error(makeSource(SERVER) + " 461 " + _clnt->getNickname() + " TOPIC :Not enough parameters\r\n");
+		} else if (!chan) {
+			throw std::logic_error(makeSource(SERVER) + " 403 " + _clnt->getNickname() + " " + chan_name + " TOPIC :No such channel\r\n");
 		} else if (!_data_manager->isChannelMember(chan, _clnt)) {
 			throw std::logic_error(makeSource(SERVER) + " 442 " + _clnt->getNickname() + " " + chan_name + " :You're not on that channel\r\n");
 		} else if (!_data_manager->isChannelOperator(chan, _clnt) && chan->getTopicOnly()) {

--- a/Executor.cpp
+++ b/Executor.cpp
@@ -77,7 +77,7 @@ void Executor::nickCommand(std::string create_time) {
 				_data_manager->sendToClient(_clnt, makeSource(SERVER) + " 004 " + nick + " :irc.seoul42.com 1.0\r\n");
 				_data_manager->sendToClient(_clnt, "PING :ping pong\r\n");
 			} else if (!_clnt->getUsername().empty()) {
-				// _data_manager->sendToClient(_clnt, makeSource(CLIENT) + " NICK " + nick + "\r\n");
+				_data_manager->sendToClient(_clnt, makeSource(CLIENT) + " NICK " + nick + "\r\n");
 				_data_manager->sendToClientChannels(_clnt, makeSource(CLIENT) + " NICK " + nick + "\r\n");
 			}
 			_clnt->setNickname(nick);
@@ -198,7 +198,7 @@ void Executor::joinCommand() {
 				// 1. RPL_TOPIC (332): 채널의 주제를 전송합니다. 주제가 없을 경우 전송되지 않을 수 있습니다.
 				_data_manager->sendToClient(_clnt, makeSource(SERVER) + " 332 " + _clnt->getNickname() + " " + chans[i] + " :" + chan->getTopic() + "\r\n");
 				// 2. RPL_TOPICWHOTIME (333): 주제를 설정한 사용자와 시간을 전송합니다. (선택적)
-				_data_manager->sendToClient(_clnt, makeSource(SERVER) + " 333 " + _clnt->getNickname() + " " + chans[i] + /* " " + chan->setBy() + " " + chan->setTime() + */"\r\n");
+				_data_manager->sendToClient(_clnt, makeSource(SERVER) + " 333 " + _clnt->getNickname() + " " + chans[i] + " " + chan->getTopicAuthor() + " " + chan->getTopicCreated() + "\r\n");
 			}
 			
 			// RPL_NAMREPLY (353): 채널에 현재 참여하고 있는 클라이언트들의 리스트를 전송합니다.
@@ -260,13 +260,20 @@ void Executor::partCommand() {
 
 void Executor::topicCommand() {
 	std::string chan_name(getParams(0));
-	Channel *chan = _data_manager->getChannel(chan_name.substr(1));
 	std::string topic(getParams(1));
 	try {
 		if (!_clnt->getPassed()) {
 			throw std::logic_error(makeSource(SERVER) + " 461 " + _clnt->getNickname() + " PASS :Not enough parameters\r\n");
 		} else if (_params.size() < 1) {
 			throw std::logic_error(makeSource(SERVER) + " 461 " + _clnt->getNickname() + " TOPIC :Not enough parameters\r\n");
+		}
+		Channel *chan = _data_manager->getChannel(chan_name.substr(1));
+		if (_params.size() == 1) {
+			if (chan->getTopic().empty()) {
+				throw std::logic_error(makeSource(SERVER) + " 331 " + _clnt->getNickname() + " " + chan_name + " No topic is set\r\n");
+			}
+			_data_manager->sendToClient(_clnt, makeSource(SERVER) + " 332 " + _clnt->getNickname() + " " + chan_name + " " + topic + "\r\n");
+			_data_manager->sendToClient(_clnt, makeSource(SERVER) + " 333 " + _clnt->getNickname() + " " + chan_name + " " + chan->getTopicAuthor() + chan->getTopicCreated() + "\r\n");
 		} else if (!chan) {
 			throw std::logic_error(makeSource(SERVER) + " 403 " + _clnt->getNickname() + " " + chan_name + " TOPIC :No such channel\r\n");
 		} else if (!_data_manager->isChannelMember(chan, _clnt)) {
@@ -276,7 +283,7 @@ void Executor::topicCommand() {
 		} else if (chan->getTopic() == topic) {
 			return ;
 		}
-		chan->setTopic(topic, _clnt->getFd());
+		chan->setTopic(topic, _clnt->getNickname() + "!" + _clnt->getUsername() + "@" + _clnt->getIp());
 		_data_manager->sendToChannel(chan, makeSource(CLIENT) + " TOPIC " + chan_name + " " + topic + "\r\n", -1);
 	} catch (const std::exception &e) {
 		_data_manager->sendToClient(_clnt, e.what());

--- a/Executor.hpp
+++ b/Executor.hpp
@@ -57,6 +57,7 @@ public:
 	void quitCommand();
 	void joinCommand();
 	void partCommand();
+	void topicCommand();
 	void kickCommand();
 	void modeCommand();
 	void privmsgCommand();

--- a/Server.cpp
+++ b/Server.cpp
@@ -113,6 +113,10 @@ void Server::parsing(Client *clnt) {
 			executor.joinCommand();
 		} else if (command == "PART") {
 			executor.partCommand();
+		} else if (command == "TOPIC") {
+			executor.topicCommand();
+		// } else if (command == "INVITE") {
+		// 	executor.inviteCommand();
 		} else if (command == "KICK") {
 			executor.kickCommand();
 		} else if (command == "MODE") {


### PR DESCRIPTION
### TOPIC 메서드 구현
- 채널 멤버 체크
- 채널 운영자 체크
- topic 중복 체크
- close #45 

### 수정사항
- 채널 join 전 topic 설정 되어있는 경우, topic author의 ip 주소가 출력되지 않는 에러
  - channel topic author의 저장방식을 `"nickname!hostname@ip"` 형태로 변경하여 해결
 - nickname 변경 적용 실패 에러
   - sendToClient() 함수 호출로 해결