### PR TITLE
PRIVMSG 메서드 receiver 다수일 경우 처리

### DIFF
--- a/Executor.cpp
+++ b/Executor.cpp
@@ -462,10 +462,11 @@ void Executor::privmsgCommand() {
 				} else {
 					if (_data_manager->getFdByNickname(receiver) == -1 || !_data_manager->getClient(_data_manager->getFdByNickname(receiver))) {
 						throw std::logic_error(makeSource(SERVER) + " 401 " + _clnt->getNickname() + " " + receiver + " :No such nick\r\n");
-					} if (!message.empty()) {
-						_data_manager->sendToClient(_data_manager->getClient(_data_manager->getFdByNickname(receiver)), 
-						makeSource(CLIENT) + " PRIVMSG " + receiver + " :" + message + "\r\n");
+					} if (message.empty()) {
+						throw std::logic_error(makeSource(SERVER) + " 412 " + _clnt->getNickname() + " :No text to send\r\n");
 					}
+					_data_manager->sendToClient(_data_manager->getClient(_data_manager->getFdByNickname(receiver)), 
+					makeSource(CLIENT) + " PRIVMSG " + receiver + " :" + message + "\r\n");
 				}
 			}
 		}


### PR DESCRIPTION
- 여러 유저/채널에게 privmsg 한 번에 보낼 경우 처리
  - receiver를 `stringstream`으로 받고, `iterator`를 통해 각 receiver 처리
  - close #72 
  

- 수정사항
  - 보낼 메시지로 빈 문자열 입력 시 412 에러 처리