### PR TITLE
MODE 메서드 채널명 # 없이 들어올 경우 처리

### DIFF
--- a/Channel.cpp
+++ b/Channel.cpp
@@ -36,6 +36,10 @@ void Channel::inviteClient(int fd) {
 	_invited.insert(fd);
 }
 
+void Channel::delInvitedClient(int fd) {
+	_invited.erase(fd);
+}
+
 void Channel::addClient(int fd, int chanops) {
 	_clients[fd] = chanops;
 }
@@ -109,14 +113,10 @@ std::string Channel::getTopicAuthor() {
 }
 
 int Channel::isInvited(int fd) {
-	int check;
 	if (_invited.find(fd) != _invited.end()) {
-		check = 1;
-	} else {
-		check = 0;
+		return 1;
 	}
-	_invited.erase(fd);
-	return check;
+	return 0;
 }
 
 std::string Channel::getModeList() {

--- a/Channel.hpp
+++ b/Channel.hpp
@@ -41,6 +41,7 @@ public:
 	void setTopic(std::string const &topic, std::string author);
 
 	void inviteClient(int fd);
+	void delInvitedClient(int fd);
 	void addClient(int fd, int chanops);
 	void delClient(int fd);
 	void addOperator(int fd);

--- a/Executor.cpp
+++ b/Executor.cpp
@@ -229,6 +229,7 @@ void Executor::joinCommand() {
 			}
 			// RPL_ENDOFNAMES (366): 클라이언트 리스트의 끝을 알리는 메시지입니다.
 			_data_manager->sendToClient(_clnt, makeSource(SERVER) + " 366 " + _clnt->getNickname() + " " + chans[i] + " :End of /NAMES list.\r\n");
+			chan->delInvitedClient(_clnt->getFd());
 		}
 	} catch (const std::exception& e) {
 		_data_manager->sendToClient(_clnt, e.what());
@@ -373,6 +374,8 @@ void Executor::modeCommand() {
 	Channel *chan = NULL;
 	if (channel_name[0] == '#') {
 		chan = _data_manager->getChannel(channel_name.substr(1));
+	} else if (_clnt->getNickname() == channel_name) {
+		return;
 	}
 	try {
 		if (!_clnt->getPassed()) {


### PR DESCRIPTION
- MODE 메서드의 채널명이 '`#`' 없이 들어올 경우 처리
  - 클라이언트 본인의 닉네임과 같을 경우 `return`
  - 그 외는 throw exception ("`No such channel`")

- `delInvitedClient()` 함수 추가
  - `inviteOnly`가 아닌 채널에 invite를 받아서 들어간 후, 나갔다가 해당 채널을 invite로 설정하고 다시 들어가면 `_Invited` 목록에서 지워지지 않아서 다시 초대받지 않고도 입장 가능한 에러 fix