### PR TITLE
QUIT / 강제 종료 시 에러 처리

### DIFF
--- a/Executor.cpp
+++ b/Executor.cpp
@@ -143,6 +143,7 @@ void Executor::pongCommand() {
 
 void Executor::quitCommand() {
 	_data_manager->sendToClientChannels(_clnt, makeSource(CLIENT) + " QUIT :Quit: " + getParams(0) + "\r\n");
+	_data_manager->sendToClient(_clnt, "");
 	_clnt->setPassed(false);
 }
 

--- a/Executor.cpp
+++ b/Executor.cpp
@@ -143,13 +143,6 @@ void Executor::pongCommand() {
 
 void Executor::quitCommand() {
 	_data_manager->sendToClientChannels(_clnt, makeSource(CLIENT) + " QUIT :Quit: " + getParams(0) + "\r\n");
-	std::set<std::string> chans = _clnt->getJoinedChannels();
-	for (std::set<std::string>::iterator it = chans.begin(); it != chans.end(); ++it) {
-		Channel *chan = _data_manager->getChannel(*it);
-		if (chan != nullptr) {
-			_data_manager->delClientFromChannel(_clnt, chan);
-		}
-	}
 	_clnt->setPassed(false);
 }
 

--- a/Server.cpp
+++ b/Server.cpp
@@ -43,10 +43,11 @@ void Server::eventReadExec(struct kevent event) {
 	if (clnt != NULL) {
 		int result = clnt->recvSocket();
 		if (result == EOF) {
-			std::cout << "closed client: " << clnt->getFd() << std::endl;
+			std::cout << "closed client read: " << clnt->getFd() << std::endl;
 			_data_manager.sendToClientChannels(clnt, ":" + clnt->getNickname() + "!" + clnt->getUsername() + "@" + clnt->getIp() + " QUIT :Client Disconnected\r\n");
 			clnt->setPassed(false);
 			_kq.delEvent(clnt->getFd(), EVFILT_READ);
+			_kq.addEvent(clnt->getFd(), EVFILT_WRITE);
 		}
 		else if (result == END) {
 			parsing(clnt);
@@ -62,7 +63,7 @@ void Server::eventWriteExec(struct kevent event) {
 			if (clnt->getPassed()) {
 				_kq.addEvent(clnt->getFd(), EVFILT_READ);
 			} else {
-				std::cout << "closed client: " << clnt->getFd() << std::endl;
+				std::cout << "closed client write: " << clnt->getFd() << std::endl;
 				std::set<std::string> chans = clnt->getJoinedChannels();
 				for (std::set<std::string>::iterator it = chans.begin(); it != chans.end(); ++it) {
 					Channel *chan = _data_manager.getChannel(*it);
@@ -70,6 +71,7 @@ void Server::eventWriteExec(struct kevent event) {
 						_data_manager.delClientFromChannel(clnt, chan);
 					}
 				}
+				_kq.delEvent(clnt->getFd(), EVFILT_TIMER);
 				_data_manager.delClient(clnt->getFd());
 				close(clnt->getFd());
 			}

--- a/Server.cpp
+++ b/Server.cpp
@@ -44,9 +44,9 @@ void Server::eventReadExec(struct kevent event) {
 		int result = clnt->recvSocket();
 		if (result == EOF) {
 			std::cout << "closed client: " << clnt->getFd() << std::endl;
+			_data_manager.sendToClientChannels(clnt, ":" + clnt->getNickname() + "!" + clnt->getUsername() + "@" + clnt->getIp() + " QUIT :Client Disconnected\r\n");
+			clnt->setPassed(false);
 			_kq.delEvent(clnt->getFd(), EVFILT_READ);
-			close(clnt->getFd());
-			_data_manager.delClient(clnt->getFd());
 		}
 		else if (result == END) {
 			parsing(clnt);
@@ -70,8 +70,8 @@ void Server::eventWriteExec(struct kevent event) {
 						_data_manager.delClientFromChannel(clnt, chan);
 					}
 				}
-				close(clnt->getFd());
 				_data_manager.delClient(clnt->getFd());
+				close(clnt->getFd());
 			}
 		}
 	}


### PR DESCRIPTION
QUIT 종료 시 자기 자신에게 `sendToClient()` 호출하는 부분이 없어서 `eventReadExec()`에서 `eventWriteExec()`로 넘어가지 않음
-> `eventWriteExec()`: 모든 클라이언트와의 연결을 끊는 과정 존재